### PR TITLE
Todo Index

### DIFF
--- a/test/controllers/todo_controller_test.exs
+++ b/test/controllers/todo_controller_test.exs
@@ -1,9 +1,8 @@
 defmodule TodoApi.TodoControllerTest do
   use TodoApi.ConnCase
+  import TodoApi.UserHelper, only: [insert_user: 0]
 
-  alias TodoApi.User
   alias TodoApi.Todo
-  alias TodoApi.Registration
 
   setup do
     conn = conn() |> put_req_header("accept", "application/json")
@@ -44,11 +43,5 @@ defmodule TodoApi.TodoControllerTest do
     response = conn |> get(todo_path(conn, :index))
 
     assert(response.status == 401)
-  end
-
-  defp insert_user do
-    %User{}
-    |> User.changeset(%{email: "email@example.com", password: "password"})
-    |> Registration.create
   end
 end

--- a/test/controllers/todo_controller_test.exs
+++ b/test/controllers/todo_controller_test.exs
@@ -1,0 +1,54 @@
+defmodule TodoApi.TodoControllerTest do
+  use TodoApi.ConnCase
+
+  alias TodoApi.User
+  alias TodoApi.Todo
+  alias TodoApi.Registration
+
+  setup do
+    conn = conn() |> put_req_header("accept", "application/json")
+    {:ok, conn: conn}
+  end
+
+  test "index returns status 200 when auth token is valid", %{conn: conn} do
+    {:ok, user} = insert_user
+
+    response = conn
+                |> put_req_header("x-auth-token", user.authentication_token)
+                |> get(todo_path(conn, :index))
+
+    assert(response.status == 200)
+  end
+
+  test "index returns todo JSON on success", %{conn: conn} do
+    {:ok, user} = insert_user
+    %Todo{content: "content", user_id: user.id} |> Repo.insert!
+
+    json = conn
+            |> put_req_header("x-auth-token", user.authentication_token)
+            |> get(todo_path(conn, :index))
+            |> json_response(200)
+
+    assert(Enum.count(json["todos"]) == 1)
+  end
+
+  test "index returns status 401 when auth token is invalid", %{conn: conn} do
+    response = conn
+                |> put_req_header("x-auth-token", "invalid-token")
+                |> get(todo_path(conn, :index))
+
+    assert(response.status == 401)
+  end
+
+  test "index returns status 401 when auth token is missing", %{conn: conn} do
+    response = conn |> get(todo_path(conn, :index))
+
+    assert(response.status == 401)
+  end
+
+  defp insert_user do
+    %User{}
+    |> User.changeset(%{email: "email@example.com", password: "password"})
+    |> Registration.create
+  end
+end

--- a/test/services/authentication_test.exs
+++ b/test/services/authentication_test.exs
@@ -17,9 +17,15 @@ defmodule TodoApi.AuthenticationTest do
     assert user.email == result.email
   end
 
-  test "returns {:error} when an invalid token is given" do
+  test "returns {:error, message} when an invalid token is given" do
     error_msg = "cannot find user by authentication token"
 
     assert {:error, error_msg} == Authentication.get_user("invalid-token")
+  end
+
+  test "returns {:error, message} when an invalid token is missing" do
+    error_msg = "a valid authentication token is required"
+
+    assert {:error, error_msg} == Authentication.get_user(nil)
   end
 end

--- a/test/services/authentication_test.exs
+++ b/test/services/authentication_test.exs
@@ -1,17 +1,11 @@
 defmodule TodoApi.AuthenticationTest do
   use TodoApi.ModelCase
+  import TodoApi.UserHelper, only: [insert_user: 0]
 
-  alias TodoApi.User
-  alias TodoApi.Registration
   alias TodoApi.Authentication
 
-  @user_params %{email: "email@example.com", password: "password"}
-
   test "returns {:ok, user} when a valid token is given" do
-    {:ok, user} = %User{}
-                  |> User.changeset(@user_params)
-                  |> Registration.create
-
+    {:ok, user} = insert_user
     {:ok, result} = Authentication.get_user(user.authentication_token)
 
     assert user.email == result.email

--- a/test/services/authentication_test.exs
+++ b/test/services/authentication_test.exs
@@ -1,0 +1,25 @@
+defmodule TodoApi.AuthenticationTest do
+  use TodoApi.ModelCase
+
+  alias TodoApi.User
+  alias TodoApi.Registration
+  alias TodoApi.Authentication
+
+  @user_params %{email: "email@example.com", password: "password"}
+
+  test "returns {:ok, user} when a valid token is given" do
+    {:ok, user} = %User{}
+                  |> User.changeset(@user_params)
+                  |> Registration.create
+
+    {:ok, result} = Authentication.get_user(user.authentication_token)
+
+    assert user.email == result.email
+  end
+
+  test "returns {:error} when an invalid token is given" do
+    error_msg = "cannot find user by authentication token"
+
+    assert {:error, error_msg} == Authentication.get_user("invalid-token")
+  end
+end

--- a/test/support/user_helper.ex
+++ b/test/support/user_helper.ex
@@ -1,0 +1,10 @@
+defmodule TodoApi.UserHelper do
+  alias TodoApi.User
+  alias TodoApi.Registration
+
+  @user_params %{email: "email@example.com", password: "password"}
+
+  def insert_user(user_params \\ @user_params) do
+    %User{} |> User.changeset(user_params) |> Registration.create
+  end
+end

--- a/web/controllers/todo_controller.ex
+++ b/web/controllers/todo_controller.ex
@@ -1,0 +1,27 @@
+defmodule TodoApi.TodoController do
+  use TodoApi.Web, :controller
+
+  alias TodoApi.Authentication
+  alias TodoApi.Todo
+  alias TodoApi.Repo
+
+  plug :authenticate_user
+
+  def index(conn, _params) do
+    user = conn.assigns[:user]
+    todos = Repo.all(Todo, user_id: user.id)
+
+    render(conn, "index.json", todos: todos)
+  end
+
+  defp authenticate_user(conn, _) do
+    authentication_token = conn.req_headers["x-auth-token"]
+
+    case Authentication.get_user(authentication_token) do
+      {:ok, user} ->
+        assign(conn, :user, user)
+      {:error, _message} ->
+        conn |> put_status(401) |> halt
+    end
+  end
+end

--- a/web/router.ex
+++ b/web/router.ex
@@ -18,6 +18,7 @@ defmodule TodoApi.Router do
 
     resources "/users", UserController, only: [:create]
     post "/authentication", AuthenticationController, :create
+    resources "/todos", TodoController, only: [:index]
   end
 
   # Other scopes may use custom stacks.

--- a/web/services/authentication.ex
+++ b/web/services/authentication.ex
@@ -12,4 +12,8 @@ defmodule TodoApi.Authentication do
         {:error, "cannot find user by authentication token"}
     end
   end
+
+  def get_user(_) do
+    {:error, "a valid authentication token is required"}
+  end
 end

--- a/web/services/authentication.ex
+++ b/web/services/authentication.ex
@@ -1,0 +1,15 @@
+defmodule TodoApi.Authentication do
+  alias TodoApi.Repo
+  alias TodoApi.User
+
+  def get_user(authentication_token) when is_binary(authentication_token) do
+    user = Repo.get_by(User, authentication_token: authentication_token)
+
+    case user do
+      %User{} ->
+        {:ok, user}
+      _ ->
+        {:error, "cannot find user by authentication token"}
+    end
+  end
+end

--- a/web/views/todo_view.ex
+++ b/web/views/todo_view.ex
@@ -1,0 +1,19 @@
+defmodule TodoApi.TodoView do
+  use TodoApi.Web, :view
+
+  def render("index.json", %{todos: todos}) do
+    %{todos: render_many(todos, TodoApi.TodoView, "todo.json")}
+  end
+
+  def render("show.json", %{todo: todo}) do
+    %{todos: render_one(todo, TodoApi.TodoView, "todo.json")}
+  end
+
+  def render("todo.json", %{todo: todo}) do
+    %{
+      id: todo.id,
+      content: todo.content,
+      completed_at: todo.completed_at
+    }
+  end
+end


### PR DESCRIPTION
- Adds an `Authentication` module.
- Adds an authentication-required "/todos" route.

An `x-auth-token` request header is required for requests to the todos index. An invalid/missing authentication token will return a 401 response.